### PR TITLE
Python 3.5 compatibility and `init [URL] [PROJECT]` params

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires = [
         'PyYAML>=5.3.1',
         'SQLAlchemy>=1.3.22',
-        'humanize>=3.2.0',
+        'humanize>=2.6.0',
         'schema>=0.7.2',
         'click>=7.1.2',
         'SQLAlchemy-Utils>=0.36.8',

--- a/stellar/command.py
+++ b/stellar/command.py
@@ -240,13 +240,12 @@ def init():
 
     with open('stellar.yaml', 'w') as project_file:
         project_file.write(
-            f"""
+            """
 project_name: {name}
 tracked_databases: ['{db_name}']
 url: '{raw_url}'
 stellar_url: '{url}stellar_data'
-            """
-        )
+            """.format(name=name, db_name=db_name, raw_url=raw_url, url=url))
 
     click.echo("Wrote stellar.yaml")
     click.echo('')

--- a/stellar/command.py
+++ b/stellar/command.py
@@ -258,12 +258,13 @@ def init(url):
 
     with open('stellar.yaml', 'w') as project_file:
         project_file.write(
-            """
-project_name: {name}
-tracked_databases: ['{db_name}']
-url: '{raw_url}'
-stellar_url: '{url}stellar_data'
-            """.format(name=name, db_name=db_name, raw_url=raw_url, url=url))
+            textwrap.dedent("""\
+                project_name: {name}
+                tracked_databases: ['{db_name}']
+                url: '{raw_url}'
+                stellar_url: '{url}stellar_data'
+                """)
+            .format(name=name, db_name=db_name, raw_url=raw_url, url=url))
 
     click.echo("Wrote stellar.yaml")
     click.echo('')

--- a/stellar/command.py
+++ b/stellar/command.py
@@ -19,7 +19,7 @@ def get_app():
     return app
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def stellar():
     """Fast database snapshots for development. It's like Git for databases."""
     pass

--- a/stellar/command.py
+++ b/stellar/command.py
@@ -171,7 +171,8 @@ def replace(name):
 
 @stellar.command()
 @click.argument('url', required=False)
-def init(url):
+@click.argument('project', required=False)
+def init(url, project):
     """Initializes Stellar configuration."""
 
     def prompt_url():
@@ -246,10 +247,11 @@ def init(url):
         db_name = url.rsplit('/', 1)[-1]
         url = url.rsplit('/', 1)[0] + '/'
 
-    name = click.prompt(
-        'Please enter your project name (used internally, eg. %s)' % db_name,
-        default=db_name
-    )
+    if project is None:
+        project = click.prompt(
+            'Please enter project name (used internally, eg. %s)' % db_name,
+            default=db_name
+        )
 
     raw_url = url
 
@@ -264,7 +266,7 @@ def init(url):
                 url: '{raw_url}'
                 stellar_url: '{url}stellar_data'
                 """)
-            .format(name=name, db_name=db_name, raw_url=raw_url, url=url))
+            .format(name=project, db_name=db_name, raw_url=raw_url, url=url))
 
     click.echo("Wrote stellar.yaml")
     click.echo('')


### PR DESCRIPTION
As I need to experiment inside old PostgreSQL docker images, I brought compatibility fixes for Python 3.5.

This also add two arguments to `init` command to make it non-interactive for scripting.

And also add short `-h` alias for `--help` to all commands.